### PR TITLE
Maintain source defaults

### DIFF
--- a/components/SyncManagement.js
+++ b/components/SyncManagement.js
@@ -25,22 +25,22 @@ export default function SyncManagement({
     workspaceAccessToken,
   )
 
-  const linkWithSourcePrepopulated = (link) => {
-    return link.uri + "&form_connection_id=" + sourceId + "&form_source_type=warehouse"
+  const linkWithSourcePrepopulated = () => {
+    return syncManagementLink.uri + "&form_connection_id=" + sourceId + "&form_source_type=warehouse"
   }
 
   const initiateSyncWizardFlow = () => {
     if (embedSourceFlow) {
       setShowCreateSyncWizard(true)
     } else {
-      window.location.href = linkWithSourcePrepopulated(syncManagementLink)
+      window.location.href = linkWithSourcePrepopulated()
     }
   }
 
   const SyncCreationWizard = () => {
     return (
       <EmbeddedFrame
-        connectLink={linkWithSourcePrepopulated(syncManagementLink)}
+        connectLink={linkWithSourcePrepopulated()}
         onExit={async (connectionDetails) => {
           if (connectionDetails.status === "created") {
             setSyncs((syncs) => [

--- a/components/SyncManagement.js
+++ b/components/SyncManagement.js
@@ -25,20 +25,22 @@ export default function SyncManagement({
     workspaceAccessToken,
   )
 
+  const linkWithSourcePrepopulated = (link) => {
+    return link.uri + "&form_connection_id=" + sourceId + "&form_source_type=warehouse"
+  }
+
   const initiateSyncWizardFlow = () => {
     if (embedSourceFlow) {
       setShowCreateSyncWizard(true)
     } else {
-      window.location.href = syncManagementLink.uri
+      window.location.href = linkWithSourcePrepopulated(syncManagementLink)
     }
   }
 
   const SyncCreationWizard = () => {
     return (
       <EmbeddedFrame
-        connectLink={
-          syncManagementLink.uri + "&form_connection_id=" + sourceId + "&form_source_type=warehouse"
-        }
+        connectLink={linkWithSourcePrepopulated(syncManagementLink)}
         onExit={async (connectionDetails) => {
           if (connectionDetails.status === "created") {
             setSyncs((syncs) => [


### PR DESCRIPTION
Pre-populate source selector defaults for embedded and redirect sync flows