### PR TITLE
New sync now says "Not run yet" instead of "Pending"

### DIFF
--- a/components/SyncStatus.js
+++ b/components/SyncStatus.js
@@ -27,7 +27,7 @@ const modes = [
   {
     status: "pending",
     className: "bg-stone-300 text-stone-50",
-    text: "Pending",
+    text: "Not run yet",
   },
   {
     status: "done",


### PR DESCRIPTION
![CleanShot 2024-05-24 at 15 57 54@2x](https://github.com/sutrolabs/census-embedded-demo/assets/65472533/1241f5bf-b279-4546-abb4-51cb598d96b0)
