### PR TITLE
updated icon for redshift from amazon shopping to aws

### DIFF
--- a/pages/integrations/import-dataset.js
+++ b/pages/integrations/import-dataset.js
@@ -57,7 +57,7 @@ export default function ImportDataset({
       <Source
         label="Redshift"
         type="redshift"
-        iconClassName="fa-brands fa-amazon"
+        iconClassName="fa-brands fa-aws"
         workspaceAccessToken={workspaceAccessToken}
         sources={sources}
         setSources={setSources}


### PR DESCRIPTION
I think the approach of showing just "AWS" is better than showing the redshift icon because otherwise we'd also have to get custom icons for Google Sheets, BigQuery, etc.

![CleanShot 2024-05-24 at 16 29 37@2x](https://github.com/sutrolabs/census-embedded-demo/assets/65472533/8c90c7c7-3ce8-496d-b264-fb2b72aa2990)
