### PR TITLE
Fix random 500 error

### DIFF
--- a/utils/preset_source_destination.js
+++ b/utils/preset_source_destination.js
@@ -1,4 +1,4 @@
-export const marketingMagnetDestinationName = "Acme"
+export const marketingMagnetDestinationName = "Marketing Magnet"
 
 export const marketingMagnetDestinationObject = "user"
 


### PR DESCRIPTION
## Description of the change

- A previous commit had accidentally changed `marketingMagnetDestinationName` to Acme from Marketing Magnet. This was causing an issue where we couldn't find destinations by that name because it didn't exist.  The primary culprit here was in `/api/get_latest_sync_run` where we couldn't find any sync runs with a destination name but also weren't throwing the proper value. This propogated a 500 error up to the top level of the app where `useFetchRuns` couldn't find any runs for the syncs with the preset destination because they didn't exist.

## How tested

- Unable to reproduce this on local so not really tested. Unsure how to on local.

## Security implications

- None that I'm aware of
